### PR TITLE
Add basic widget tests

### DIFF
--- a/test/widgets/custom_elevated_button_test.dart
+++ b/test/widgets/custom_elevated_button_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drive_or_drunk_app/widgets/custom_elevated_button.dart';
+
+void main() {
+  testWidgets('CustomElevatedButton displays label and reacts to tap', (tester) async {
+    var tapped = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: CustomElevatedButton(
+            onPressed: () => tapped = true,
+            labelText: 'Press Me',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Press Me'), findsOneWidget);
+
+    await tester.tap(find.byType(CustomElevatedButton));
+    expect(tapped, isTrue);
+  });
+}

--- a/test/widgets/custom_filled_button_test.dart
+++ b/test/widgets/custom_filled_button_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drive_or_drunk_app/widgets/custom_filled_button.dart';
+
+void main() {
+  testWidgets('CustomFilledButton displays label and reacts to tap', (tester) async {
+    var tapped = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: CustomFilledButton(
+            onPressed: () => tapped = true,
+            labelText: 'Submit',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Submit'), findsOneWidget);
+
+    await tester.tap(find.byType(CustomFilledButton));
+    expect(tapped, isTrue);
+  });
+}

--- a/test/widgets/custom_future_builder_test.dart
+++ b/test/widgets/custom_future_builder_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drive_or_drunk_app/widgets/custom_future_builder.dart';
+
+void main() {
+  testWidgets('CustomFutureBuilder displays data when future completes', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CustomFutureBuilder<String>(
+          future: Future.value('hello'),
+          component: (data) => Text(data),
+        ),
+      ),
+    );
+
+    // pump until the future completes
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
+
+    expect(find.text('hello'), findsOneWidget);
+  });
+}

--- a/test/widgets/custom_stream_builder_test.dart
+++ b/test/widgets/custom_stream_builder_test.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drive_or_drunk_app/widgets/custom_stream_builder.dart';
+
+void main() {
+  testWidgets('CustomStreamBuilder shows list items', (tester) async {
+    final controller = StreamController<List<int>>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CustomStreamBuilder<int>(
+          stream: controller.stream,
+          customListTileBuilder: (item) => Text('item $item'),
+        ),
+      ),
+    );
+
+    controller.add([1, 2]);
+    await tester.pump();
+
+    expect(find.text('item 1'), findsOneWidget);
+    expect(find.text('item 2'), findsOneWidget);
+
+    await controller.close();
+  });
+}

--- a/test/widgets/custom_text_form_field_test.dart
+++ b/test/widgets/custom_text_form_field_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drive_or_drunk_app/widgets/custom_text_form_field.dart';
+
+void main() {
+  testWidgets('CustomTextFormField updates controller text', (tester) async {
+    final controller = TextEditingController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: CustomTextFormField(
+            controller: controller,
+            labelText: 'Email',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Email'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextFormField), 'foo');
+    expect(controller.text, 'foo');
+  });
+}

--- a/test/widgets/star_rating_test.dart
+++ b/test/widgets/star_rating_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drive_or_drunk_app/widgets/star_rating.dart';
+
+void main() {
+  testWidgets('StarRating shows correct star icons', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: StarRating(rating: 3.5, size: 24),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.star), findsNWidgets(3));
+    expect(find.byIcon(Icons.star_half), findsOneWidget);
+    expect(find.byIcon(Icons.star_border), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add tests for various custom widgets

## Testing
- `flutter test test/widgets/custom_elevated_button_test.dart` *(fails: flutter not found)*
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863cf2fc200833285ddcdd010b929a1