### PR TITLE
Add tests for reviews and profile widgets

### DIFF
--- a/lib/widgets/profile_ratingcard.dart
+++ b/lib/widgets/profile_ratingcard.dart
@@ -9,7 +9,7 @@ import 'package:drive_or_drunk_app/widgets/star_rating.dart';
 import 'package:flutter/material.dart';
 
 class ProfileRatingcard extends StatelessWidget {
-  final FirestoreService db = FirestoreService();
+  final FirestoreService db;
   final user_model.User owner;
   final String reviewType;
 
@@ -17,7 +17,8 @@ class ProfileRatingcard extends StatelessWidget {
     super.key,
     required this.owner,
     required this.reviewType,
-  });
+    FirestoreService? db,
+  }) : db = db ?? FirestoreService();
 
   @override
   Widget build(BuildContext context) {

--- a/test/widgets/custom_dropdown_test.dart
+++ b/test/widgets/custom_dropdown_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drive_or_drunk_app/widgets/custom_dropdown.dart';
+
+void main() {
+  testWidgets('CustomDropdown shows provided child', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            return MaterialButton(
+              onPressed: () {
+                CustomDropdown.show(
+                  context: context,
+                  child: const Text('Dropdown content'),
+                );
+              },
+              child: const Text('Open'),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Dropdown content'), findsOneWidget);
+  });
+
+  testWidgets('CustomDropdown dismiss callback is triggered', (tester) async {
+    var dismissed = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(builder: (context) {
+          return MaterialButton(
+            onPressed: () {
+              CustomDropdown.show(
+                context: context,
+                child: const Text('Dropdown content'),
+                onDismiss: () => dismissed = true,
+              );
+            },
+            child: const Text('Open'),
+          );
+        }),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+
+    expect(dismissed, isTrue);
+  });
+}

--- a/test/widgets/date_input_field_test.dart
+++ b/test/widgets/date_input_field_test.dart
@@ -16,4 +16,40 @@ void main() {
     await tester.enterText(find.byType(TextFormField), '01/01/2025');
     expect(controller.text, '01/01/2025');
   });
+
+  testWidgets('DateInputField validates required on save', (tester) async {
+    final controller = TextEditingController();
+    final formKey = GlobalKey<FormState>();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Form(
+            key: formKey,
+            child: DateInputField(controller: controller, required: true),
+          ),
+        ),
+      ),
+    );
+
+    formKey.currentState!.save();
+    await tester.pump();
+
+    expect(find.text('Please enter a date'), findsOneWidget);
+  });
+
+  testWidgets('DateInputField clear icon clears text', (tester) async {
+    final controller = TextEditingController(text: '01/01/2025');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: DateInputField(controller: controller),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.clear));
+    await tester.pump();
+
+    expect(controller.text, '');
+  });
 }

--- a/test/widgets/google_maps_test.dart
+++ b/test/widgets/google_maps_test.dart
@@ -1,0 +1,47 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:drive_or_drunk_app/models/event_model.dart';
+import 'package:drive_or_drunk_app/widgets/google_maps.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+void main() {
+  test('meters to lat/lng conversions', () {
+    expect(metersToLatitude(111320), closeTo(1, 0.0001));
+    expect(metersToLongitude(111320, 0), closeTo(1, 0.0001));
+  });
+
+  test('isLocationWithinRadius works', () {
+    final location = const GeoPoint(0, 0);
+    final center = const LatLng(0, 0);
+    expect(isLocationWithinRadius(location, center, 1000), isTrue);
+  });
+
+  testWidgets('create marker utilities', (tester) async {
+    final event = Event(
+      id: '1',
+      name: 'Test',
+      author: '1',
+      place: 'A',
+      date: DateTime.now(),
+      location: const GeoPoint(1, 2),
+    );
+
+    await tester.pumpWidget(const MaterialApp(home: Material()));
+
+    final marker = createMarker(
+      tester.element(find.byType(Material)),
+      event: event,
+    );
+
+    expect(marker.markerId.value, '1');
+    expect(marker.position.latitude, 1);
+    expect(marker.position.longitude, 2);
+
+    final markers = createMarkersFromEvents(
+      tester.element(find.byType(Material)),
+      [event],
+    );
+    expect(markers.containsKey('1'), isTrue);
+  });
+}

--- a/test/widgets/image_input_field_test.dart
+++ b/test/widgets/image_input_field_test.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drive_or_drunk_app/widgets/image_input_field.dart';
+
+void main() {
+  testWidgets('ImageInputField shows select text', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Material(
+        child: ImageInputField(onImageSelected: _onSelected),
+      ),
+    ));
+
+    expect(find.text('Select Image'), findsOneWidget);
+  });
+}
+
+void _onSelected(File _) {}

--- a/test/widgets/profile_ratingcard_test.dart
+++ b/test/widgets/profile_ratingcard_test.dart
@@ -1,0 +1,66 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:drive_or_drunk_app/models/review_model.dart';
+import 'package:drive_or_drunk_app/models/user_model.dart' as user_model;
+import 'package:drive_or_drunk_app/services/firestore_service.dart';
+import 'package:drive_or_drunk_app/widgets/profile_ratingcard.dart';
+import 'package:drive_or_drunk_app/widgets/reviews_preview.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class FakeDocumentReference<T> extends Fake implements DocumentReference<T> {}
+
+class FakeFirestoreService extends FirestoreService {
+  FakeFirestoreService({required this.author, this.avg = 4.0, this.reviews = const []});
+
+  final user_model.User author;
+  final double avg;
+  final List<Review> reviews;
+
+  @override
+  Future<double> getAverageRating(user_model.User owner, String type) async => avg;
+
+  @override
+  Future<List<Review>> getReviewsByType(user_model.User owner, String type) async => reviews;
+
+  @override
+  Future<user_model.User> getAuthor(Review review) async => author;
+}
+
+void main() {
+  testWidgets('ProfileRatingcard shows message when no reviews', (tester) async {
+    final owner = user_model.User(id: '1', name: 'Owner', username: 'o', email: 'o@a');
+    final service = FakeFirestoreService(author: owner, reviews: []);
+
+    await tester.pumpWidget(MaterialApp(
+      home: ProfileRatingcard(owner: owner, reviewType: ReviewType.driver, db: service),
+    ));
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
+
+    expect(find.text('No reviews available for this user.\n'), findsOneWidget);
+  });
+
+  testWidgets('ProfileRatingcard shows rating and preview', (tester) async {
+    final owner = user_model.User(id: '1', name: 'Owner', username: 'o', email: 'o@a');
+    final review = Review(
+      id: 'r',
+      author: FakeDocumentReference(),
+      type: ReviewType.driver,
+      text: 'Great driver',
+      rating: 5,
+      timestamp: Timestamp.now(),
+    );
+    final service = FakeFirestoreService(author: owner, reviews: [review]);
+
+    await tester.pumpWidget(MaterialApp(
+      home: ProfileRatingcard(owner: owner, reviewType: ReviewType.driver, db: service),
+    ));
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
+
+    expect(find.byType(ReviewsPreview), findsOneWidget);
+    expect(find.text('Great driver'), findsOneWidget);
+  });
+}

--- a/test/widgets/reviews_list_body_test.dart
+++ b/test/widgets/reviews_list_body_test.dart
@@ -1,0 +1,42 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:drive_or_drunk_app/models/review_model.dart';
+import 'package:drive_or_drunk_app/models/user_model.dart' as user_model;
+import 'package:drive_or_drunk_app/services/firestore_service.dart';
+import 'package:drive_or_drunk_app/widgets/reviews_list_body.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class FakeDocumentReference<T> extends Fake implements DocumentReference<T> {}
+
+class FakeFirestoreService extends FirestoreService {
+  FakeFirestoreService(this.author);
+  final user_model.User author;
+
+  @override
+  Future<user_model.User> getAuthor(Review review) async => author;
+}
+
+void main() {
+  testWidgets('ReviewsListBody displays review and author', (tester) async {
+    final author = user_model.User(id: 'u', name: 'Bob', username: 'b', email: 'b@a');
+    final service = FakeFirestoreService(author);
+    final review = Review(
+      id: 'r',
+      author: FakeDocumentReference(),
+      type: ReviewType.driver,
+      text: 'Nice',
+      rating: 4,
+      timestamp: Timestamp.now(),
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: ReviewsListBody(db: service, item: review),
+    ));
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
+
+    expect(find.text('BOB'), findsOneWidget);
+    expect(find.textContaining('Nice'), findsOneWidget);
+  });
+}

--- a/test/widgets/reviews_preview_test.dart
+++ b/test/widgets/reviews_preview_test.dart
@@ -1,0 +1,42 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:drive_or_drunk_app/models/review_model.dart';
+import 'package:drive_or_drunk_app/models/user_model.dart' as user_model;
+import 'package:drive_or_drunk_app/services/firestore_service.dart';
+import 'package:drive_or_drunk_app/widgets/reviews_preview.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class FakeDocumentReference<T> extends Fake implements DocumentReference<T> {}
+
+class FakeFirestoreService extends FirestoreService {
+  FakeFirestoreService(this.author);
+  final user_model.User author;
+
+  @override
+  Future<user_model.User> getAuthor(Review review) async => author;
+}
+
+void main() {
+  testWidgets('ReviewsPreview shows first review and author', (tester) async {
+    final author = user_model.User(id: 'u', name: 'Bob', username: 'b', email: 'b@a');
+    final service = FakeFirestoreService(author);
+    final review = Review(
+      id: 'r',
+      author: FakeDocumentReference(),
+      type: ReviewType.driver,
+      text: 'Nice',
+      rating: 4,
+      timestamp: Timestamp.now(),
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: ReviewsPreview(reviews: [review], db: service),
+    ));
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
+
+    expect(find.text('BOB'), findsOneWidget);
+    expect(find.textContaining('Nice'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add a `ProfileRatingcard` test with fake Firestore service
- cover `ReviewsListBody` and `ReviewsPreview`
- extend `DateInputField` tests for validation and clear icon

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686407e154e48332a3ae826037c2d4d3